### PR TITLE
Fix single chunk saving in RAG agent

### DIFF
--- a/phase_1/workflow_agents/base_agents.py
+++ b/phase_1/workflow_agents/base_agents.py
@@ -146,7 +146,13 @@ class RAGKnowledgePromptAgent:
         text = re.sub(r'\s+', ' ', text).strip()
 
         if len(text) <= self.chunk_size:
-            return [{"chunk_id": 0, "text": text, "chunk_size": len(text)}]
+            chunks = [{"chunk_id": 0, "text": text, "chunk_size": len(text)}]
+            with open(f"chunks-{self.unique_filename}", 'w', newline='', encoding='utf-8') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=["text", "chunk_size"])
+                writer.writeheader()
+                for chunk in chunks:
+                    writer.writerow({k: chunk[k] for k in ["text", "chunk_size"]})
+            return chunks
 
         chunks, start, chunk_id = [], 0, 0
 


### PR DESCRIPTION
## Summary
- ensure `RAGKnowledgePromptAgent.chunk_text` writes chunk file even when text fits in a single chunk

## Testing
- `python phase_1/run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687b96d2dffc832b8883de6c90e90b89