### PR TITLE
Add Streamlit test dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ The script prints the steps derived from the action plan and the final output pr
 - `embeddings-*.csv` – embeddings of those chunks
 - `test_output_*.txt` – logs from each test script
 
+## Streamlit Test Dashboard
+
+Run a small dashboard to execute the test scripts from a browser. Start it with:
+
+```bash
+streamlit run test_dashboard.py
+```
+
+The page lets you run individual tests or all of them and shows the log files
+generated in `phase_1`.
+
 ## License
 
 MIT License. Feel free to use and adapt this project.

--- a/test_dashboard.py
+++ b/test_dashboard.py
@@ -1,0 +1,44 @@
+import os
+import glob
+import subprocess
+import streamlit as st
+
+TEST_DIR = "phase_1"
+
+st.title("Agentic Workflow Test Dashboard")
+
+# Find all test scripts
+TEST_PATTERN = os.path.join(TEST_DIR, "test_*.py")
+TEST_SCRIPTS = sorted(glob.glob(TEST_PATTERN))
+
+# Run selected test
+def run_script(script_path):
+    """Run a python script and capture its output."""
+    result = subprocess.run(
+        ["python", script_path], capture_output=True, text=True
+    )
+    return result.stdout + result.stderr
+
+selected_test = st.selectbox("Select a test to run", TEST_SCRIPTS)
+
+if st.button("Run Selected Test"):
+    st.write(f"Running **{selected_test}**...")
+    output = run_script(selected_test)
+    st.text_area("Test Output", output, height=300)
+
+if st.button("Run All Tests"):
+    run_all = os.path.join(TEST_DIR, "run_all_tests.py")
+    st.write("Running all tests...")
+    output = run_script(run_all)
+    st.text_area("All Tests Output", output, height=300)
+
+# Display test logs if they exist
+log_files = sorted(glob.glob(os.path.join(TEST_DIR, "test_output_*.txt")))
+if log_files:
+    st.header("Test Logs")
+    for log in log_files:
+        with st.expander(os.path.basename(log)):
+            with open(log, "r", encoding="utf-8") as f:
+                st.text(f.read())
+else:
+    st.info("No log files found. Run a test to generate logs.")


### PR DESCRIPTION
## Summary
- add `test_dashboard.py` to run individual or all tests in the browser
- document Streamlit dashboard in README

## Testing
- `python -m py_compile test_dashboard.py`
- `python phase_1/run_all_tests.py` *(fails: Command '['python', 'test_augmented_prompt_agent.py']' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_687b9be8ff94832b9cab6a495aa220cd