### PR TITLE
Fix Unicode prints

### DIFF
--- a/phase_1/action_planning_agent.py
+++ b/phase_1/action_planning_agent.py
@@ -43,6 +43,6 @@ agent = ActionPlanningAgent(openai_api_key=openai_api_key, knowledge=knowledge)
 prompt = "One morning I wanted to have scrambled eggs"
 steps = agent.extract_steps_from_prompt(prompt)
 
-print("🧑‍🍳 Steps for the task:")
+print("Steps for the task:")
 for idx, step in enumerate(steps, 1):
     print(f"{idx}. {step}")

--- a/phase_1/rag_knowledge_prompt_agent.py
+++ b/phase_1/rag_knowledge_prompt_agent.py
@@ -60,10 +60,10 @@ embeddings_df = rag_agent.calculate_embeddings()
 # TODO: 5 - Ask a prompt and print the response
 prompt = "What is the podcast that Clara hosts about?"
 
-print("\n📌 Prompt:")
+print("\nPrompt:")
 print(prompt)
 
 response = rag_agent.find_prompt_in_knowledge(prompt)
 
-print("\n🎓 RAG Agent Response:")
+print("\nRAG Agent Response:")
 print(response)

--- a/phase_1/routing_agent.py
+++ b/phase_1/routing_agent.py
@@ -70,6 +70,6 @@ prompts = [
 ]
 
 for prompt in prompts:
-    print("\n📌 Prompt:", prompt)
+    print("\nPrompt:", prompt)
     response = routing_agent.route(prompt)
-    print("🤖 Routed Response:", response)
+    print("Routed Response:", response)

--- a/phase_1/run_all_tests.py
+++ b/phase_1/run_all_tests.py
@@ -11,15 +11,15 @@ tests = [
     ("test_rag_knowledge_agent.py", "test_output_rag_agent.txt")
 ]
 
-print("🚀 Running agent test scripts...\n")
+print("Running agent test scripts...\n")
 
 for script, output_file in tests:
-    print(f"▶️ Executing {script}...")
+    print(f"Executing {script}...")
     try:
         with open(output_file, "w", encoding="utf-8") as out:
             subprocess.run(["python", script], stdout=out, stderr=subprocess.STDOUT, check=True)
-        print(f"✅ Output saved to {output_file}\n")
+        print(f"Output saved to {output_file}\n")
     except subprocess.CalledProcessError as e:
-        print(f"❌ Error running {script}: {e}\n")
+        print(f"Error running {script}: {e}\n")
 
-print("🏁 All tests completed.")
+print("All tests completed.")

--- a/phase_1/test_rag_knowledge_agent.py
+++ b/phase_1/test_rag_knowledge_agent.py
@@ -21,11 +21,11 @@ agent = RAGKnowledgePromptAgent(api_key, persona="A science journalist", chunk_s
 
 # Gera os chunks e garante que o arquivo CSV será salvo com nome único
 chunks = agent.chunk_text(knowledge)
-print(f"✔️ Chunks gerados: {len(chunks)}")
+print(f"Chunks gerados: {len(chunks)}")
 
 # Calcula embeddings e salva no CSV
 df_embeddings = agent.calculate_embeddings()
-print(f"✔️ Embeddings calculados: {len(df_embeddings)}")
+print(f"Embeddings calculados: {len(df_embeddings)}")
 
 # Executa busca baseada em similaridade e gera resposta
 response = agent.find_prompt_in_knowledge(prompt)

--- a/phase_1/workflow_agents/base_agents.py
+++ b/phase_1/workflow_agents/base_agents.py
@@ -262,7 +262,7 @@ class EvaluationAgent:
             print(f"Evaluator Agent Evaluation:\n{evaluation}")
 
             if evaluation.lower().startswith("yes"):  # TODO 6
-                print("✅ Final solution accepted.")
+                print("Final solution accepted.")
                 return {
                     "final_response": response_from_worker,
                     "evaluation": evaluation,


### PR DESCRIPTION
## Summary
- sanitize run_all_tests to avoid Unicode errors
- remove emoji from the recipe agent example
- clean output labels for routing and RAG agents
- drop emoji from RAG test script
- avoid emoji in EvaluationAgent

## Testing
- `python run_all_tests.py` *(fails: Command '['python', ...] returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_687b9dbdfa04832ba09363592a44193f